### PR TITLE
input_uvc MJPEG mode bug

### DIFF
--- a/mjpg-streamer/plugins/input_uvc/v4l2uvc.c
+++ b/mjpg-streamer/plugins/input_uvc/v4l2uvc.c
@@ -439,7 +439,7 @@ int uvcGrab(struct vdIn *vd)
             /* Prevent crash
                                                         * on empty image */
             fprintf(stderr, "Ignoring empty buffer ...\n");
-            return 0;
+            break;
         }
 
         /* memcpy(vd->tmpbuffer, vd->mem[vd->buf.index], vd->buf.bytesused);

--- a/mjpg-streamer/plugins/input_uvc/v4l2uvc.c
+++ b/mjpg-streamer/plugins/input_uvc/v4l2uvc.c
@@ -292,7 +292,7 @@ static int init_v4l2(struct vdIn *vd)
     /*
      * map the buffers
      */
-    for(i = 0; i < NB_BUFFER; i++) {
+    for(i = 0; i < vd->rb.count; i++) {
         memset(&vd->buf, 0, sizeof(struct v4l2_buffer));
         vd->buf.index = i;
         vd->buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
@@ -320,7 +320,7 @@ static int init_v4l2(struct vdIn *vd)
     /*
      * Queue the buffers.
      */
-    for(i = 0; i < NB_BUFFER; ++i) {
+    for(i = 0; i < vd->rb.count; ++i) {
         memset(&vd->buf, 0, sizeof(struct v4l2_buffer));
         vd->buf.index = i;
         vd->buf.type = V4L2_BUF_TYPE_VIDEO_CAPTURE;
@@ -754,7 +754,7 @@ int setResolution(struct vdIn *vd, int width, int height)
     if(video_disable(vd, STREAMING_PAUSED) == 0) {  // do streamoff
         DBG("Unmap buffers\n");
         int i;
-        for(i = 0; i < NB_BUFFER; i++)
+        for(i = 0; i < vd->rb.count; i++)
             munmap(vd->mem[i], vd->buf.length);
 
         if(CLOSE_VIDEO(vd->fd) == 0) {


### PR DESCRIPTION
input_uvc might block on ioctl(VIDIOC_DQBUF).
there is not VIDIOC_QBUF when detect empty image.